### PR TITLE
- More things related to Sendinblue migration

### DIFF
--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/MailServiceImpl.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/MailServiceImpl.java
@@ -26,8 +26,8 @@ import sibModel.SendSmtpEmailTo;
 @Slf4j
 public class MailServiceImpl implements MailService {
     private final TransactionalEmailsApi apiInstance;
-    @Value("${tenant.domain}")
-    private String tenantDomain;
+    @Value("${sendinblue.url.domain}")
+    private String sendinBlueUrlDomain;
     @Value("${email.support}")
     private String emailSupport;
     @Value("${sendinblue.template.id.welcome}")
@@ -64,7 +64,7 @@ public class MailServiceImpl implements MailService {
     public void sendEmailConfirmAccount(User user, ConfirmationToken confirmationToken) {
         Map<String, String> variables = new HashMap<>();
         variables.put("confirmToken", confirmationToken.getToken());
-        variables.put("tenantDomain", tenantDomain);
+        variables.put("sendinBlueUrlDomain", sendinBlueUrlDomain);
 
         SendSmtpEmailTo sendSmtpEmailTo = new SendSmtpEmailTo();
         sendSmtpEmailTo.setEmail(user.getEmail());
@@ -91,7 +91,7 @@ public class MailServiceImpl implements MailService {
         Map<String, String> variables = new HashMap<>();
         variables.put("newPasswordToken", passwordRecoveryToken.getToken());
         variables.put("PRENOM", user.getFirstName());
-        variables.put("tenantDomain", tenantDomain);
+        variables.put("sendinBlueUrlDomain", sendinBlueUrlDomain);
 
         SendSmtpEmailTo sendSmtpEmailTo = new SendSmtpEmailTo();
         sendSmtpEmailTo.setEmail(user.getEmail());
@@ -119,7 +119,7 @@ public class MailServiceImpl implements MailService {
         Long templateId = templateIdCoupleApplication;
         variables.put("PRENOM", flatmate.getFirstName());
         variables.put("confirmToken", passwordRecoveryToken.getToken());
-        variables.put("tenantDomain", tenantDomain);
+        variables.put("sendinBlueUrlDomain", sendinBlueUrlDomain);
         if (applicationType == ApplicationType.GROUP) {
             variables.put("NOM", Strings.isNullOrEmpty(flatmate.getPreferredName()) ? flatmate.getLastName() : flatmate.getPreferredName());
             templateId = templateIdGroupApplication;
@@ -200,7 +200,7 @@ public class MailServiceImpl implements MailService {
         variables.put("PRENOM", user.getFirstName());
         variables.put("NOM", Strings.isNullOrEmpty(user.getPreferredName()) ? user.getLastName() : user.getPreferredName());
         variables.put("confirmToken", confirmationToken.getToken());
-        variables.put("tenantDomain", tenantDomain);
+        variables.put("sendinBlueUrlDomain", sendinBlueUrlDomain);
 
         SendSmtpEmailTo sendSmtpEmailTo = new SendSmtpEmailTo();
         sendSmtpEmailTo.setEmail(user.getEmail());
@@ -226,7 +226,7 @@ public class MailServiceImpl implements MailService {
         Map<String, String> variables = new HashMap<>();
         variables.put("PRENOM", user.getFirstName());
         variables.put("NOM", Strings.isNullOrEmpty(user.getPreferredName()) ? user.getLastName() : user.getPreferredName());
-        variables.put("tenantDomain", tenantDomain);
+        variables.put("sendinBlueUrlDomain", sendinBlueUrlDomain);
 
         SendSmtpEmailTo sendSmtpEmailTo = new SendSmtpEmailTo();
         sendSmtpEmailTo.setEmail(user.getEmail());
@@ -312,10 +312,10 @@ public class MailServiceImpl implements MailService {
     @Override
     public void sendEmailFirstWarningForDeletionOfDocuments(User user, ConfirmationToken confirmationToken) {
         Map<String, String> variables = new HashMap<>();
-        variables.put("firstName", user.getFirstName());
-        variables.put("lastName", Strings.isNullOrEmpty(user.getPreferredName()) ? user.getLastName() : user.getPreferredName());
+        variables.put("PRENOM", user.getFirstName());
+        variables.put("NOM", Strings.isNullOrEmpty(user.getPreferredName()) ? user.getLastName() : user.getPreferredName());
         variables.put("confirmToken", confirmationToken.getToken());
-        variables.put("tenantDomain", tenantDomain);
+        variables.put("sendinBlueUrlDomain", sendinBlueUrlDomain);
 
         SendSmtpEmailTo sendSmtpEmailTo = new SendSmtpEmailTo();
         sendSmtpEmailTo.setEmail(user.getEmail());
@@ -338,10 +338,10 @@ public class MailServiceImpl implements MailService {
     @Override
     public void sendEmailSecondWarningForDeletionOfDocuments(User user, ConfirmationToken confirmationToken) {
         Map<String, String> variables = new HashMap<>();
-        variables.put("firstName", user.getFirstName());
-        variables.put("lastName", Strings.isNullOrEmpty(user.getPreferredName()) ? user.getLastName() : user.getPreferredName());
+        variables.put("PRENOM", user.getFirstName());
+        variables.put("NOM", Strings.isNullOrEmpty(user.getPreferredName()) ? user.getLastName() : user.getPreferredName());
         variables.put("confirmToken", confirmationToken.getToken());
-        variables.put("tenantDomain", tenantDomain);
+        variables.put("sendinBlueUrlDomain", sendinBlueUrlDomain);
 
         SendSmtpEmailTo sendSmtpEmailTo = new SendSmtpEmailTo();
         sendSmtpEmailTo.setEmail(user.getEmail());

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/service/MailService.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/service/MailService.java
@@ -21,8 +21,8 @@ import sibModel.SendSmtpEmailTo;
 @Slf4j
 public class MailService {
     private final TransactionalEmailsApi apiInstance;
-    @Value("${tenant.domain}")
-    private String tenantDomain;
+    @Value("${sendinblue.url.domain}")
+    private String sendinBlueUrlDomain;
     @Value("${sendinblue.template.id.message.notification}")
     private Long templateIDMessageNotification;
     @Value("${sendinblue.template.id.account.deleted}")
@@ -59,7 +59,7 @@ public class MailService {
         Map<String, String> variables = new HashMap<>();
         variables.put("PRENOM", user.getFirstName());
         variables.put("NOM", Strings.isNullOrEmpty(user.getPreferredName()) ? user.getLastName() : user.getPreferredName());
-        variables.put("tenantDomain", tenantDomain);
+        variables.put("sendinBlueUrlDomain", sendinBlueUrlDomain);
 
         SendSmtpEmailTo sendSmtpEmailTo = new SendSmtpEmailTo();
         sendSmtpEmailTo.setEmail(user.getEmail());
@@ -84,7 +84,7 @@ public class MailService {
         Map<String, String> variables = new HashMap<>();
         variables.put("PRENOM", tenant.getFirstName());
         variables.put("NOM", Strings.isNullOrEmpty(tenant.getPreferredName()) ? tenant.getLastName() : tenant.getPreferredName());
-        variables.put("tenantDomain", tenantDomain);
+        variables.put("sendinBlueUrlDomain", sendinBlueUrlDomain);
 
         SendSmtpEmailTo sendSmtpEmailTo = new SendSmtpEmailTo();
         sendSmtpEmailTo.setEmail(tenant.getEmail());

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantCommonRepository.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantCommonRepository.java
@@ -183,11 +183,10 @@ public interface TenantCommonRepository extends JpaRepository<Tenant, Long> {
     )
     List<Tenant> findAllTenantsYESAssociatedToPartnersAndValidatedSinceXDaysAgo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
-    @Query(value = "select * from tenant t \n" +
-            "join user_account u on u.id = t.id \n" +
-            "where u.last_login_date < :localDateTime \n" +
-            "and t.id in (select d.tenant_id from document d where d.tenant_id is not null) \n" +
-            "and t.warnings = :warnings", nativeQuery = true)
+    @Query(value = "from Tenant t " +
+            "where t.lastLoginDate < :localDateTime " +
+            "and t.warnings = :warnings " +
+            "and t.id in (select d.tenant.id from Document d where d.tenant.id is not null)")
     Page<Tenant> findByLastLoginDateIsBeforeAndHasDocuments(Pageable pageable, @Param("localDateTime") LocalDateTime localDateTime, Integer warnings);
 
     @Modifying


### PR DESCRIPTION
- Changing variable from "tenantDomain" to "sendinBlueUrlDomain" in all templates and in code.
- Using confirmToken in first and second warnings.
- Changing variable from "firstName" to "PRENOM" and "lastName" to "NOM" in templates for first and second warnings.
- Updating query findByLastLoginDateIsBeforeAndHasDocuments to avoid loading Tenants with firstName and lastName in null.